### PR TITLE
Multiple changes

### DIFF
--- a/src/crud/crud_heatmap_closest_average.py
+++ b/src/crud/crud_heatmap_closest_average.py
@@ -75,7 +75,7 @@ class CRUDHeatmapClosestAverageActiveMobility(CRUDHeatmapClosestAverageBase):
 
         # Create feature layer to store computed heatmap output
         layer_heatmap = IFeatureLayerToolCreate(
-            name=DefaultResultLayerName.heatmap_gravity_active_mobility.value,
+            name=DefaultResultLayerName.heatmap_closest_average_active_mobility.value,
             feature_layer_geometry_type=FeatureGeometryType.polygon,
             attribute_mapping={
                 "text_attr1": "h3_index",

--- a/src/crud/crud_oev_gueteklasse.py
+++ b/src/crud/crud_oev_gueteklasse.py
@@ -338,8 +338,8 @@ class CRUDOevGueteklasse(CRUDToolBase):
             name=DefaultResultLayerName.oev_gueteklasse_station.value,
             feature_layer_geometry_type=UserDataGeomType.point.value,
             attribute_mapping={
-                "text_attr1": "stop_name",
-                "text_attr2": "stop_id",
+                "text_attr1": "stop_id",
+                "text_attr2": "stop_name",
                 "float_attr1": "frequency",
                 "integer_attr1": "station_category",
             },

--- a/src/endpoints/v2/job.py
+++ b/src/endpoints/v2/job.py
@@ -76,12 +76,12 @@ async def read_jobs(
         description="Specify if the job should be read. If not specified, all jobs will be returned.",
     ),
     order_by: str = Query(
-        None,
+        default="created_at",
         description="Specify the column name that should be used to order. You can check the Layer model to see which column names exist.",
         example="created_at",
     ),
     order: OrderEnum = Query(
-        "descendent",
+        default="descendent",
         description="Specify the order to apply. There are the option ascendent or descendent.",
         example="descendent",
     ),

--- a/src/schemas/catchment_area.py
+++ b/src/schemas/catchment_area.py
@@ -165,7 +165,7 @@ class CatchmentAreaTravelTimeCostMotorizedMobility(BaseModel):
         title="Max Travel Time",
         description="The maximum travel time in minutes.",
         ge=1,
-        le=60,
+        le=90,
     )
     steps: int = Field(
         ...,

--- a/src/schemas/toolbox_base.py
+++ b/src/schemas/toolbox_base.py
@@ -49,12 +49,12 @@ class DefaultResultLayerName(str, Enum):
     buffer = "Buffer"
     origin_destination_relation = "O-D Relation"
     origin_destination_point = "O-D Point"
-    heatmap_gravity_active_mobility = "Heatmap (gravity)"
-    heatmap_gravity_motorized_mobility = "Heatmap (gravity)"
-    heatmap_closest_average_active_mobility = "Heatmap (closest average)"
-    heatmap_closest_average_motorized_mobility = "Heatmap (closest average)"
-    heatmap_connectivity_active_mobility = "Heatmap (connectivity)"
-    heatmap_connectivity_motorized_mobility = "Heatmap (connectivity)"
+    heatmap_gravity_active_mobility = "Heatmap - Gravity"
+    heatmap_gravity_motorized_mobility = "Heatmap - Gravity"
+    heatmap_closest_average_active_mobility = "Heatmap - Closest Average"
+    heatmap_closest_average_motorized_mobility = "Heatmap - Closest Average"
+    heatmap_connectivity_active_mobility = "Heatmap - Connectivity"
+    heatmap_connectivity_motorized_mobility = "Heatmap - Connectivity"
 
 class MaxFeatureCnt(int, Enum):
     """Max feature count schema."""


### PR DESCRIPTION
- Fix ÖV Güteklasse attribute mapping
- Allow upto 90-minute catchment area for PT & Car
- Order jobs by their "created_at" timestamp by default
- Fix output layer name for closest average heatmap
- Update output layer names for all heatmap types to follow convention